### PR TITLE
fix Git source URL in *.rockspec

### DIFF
--- a/rocks/sdl2-scm-1.rockspec
+++ b/rocks/sdl2-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "sdl2"
 version = "scm-1"
 
 source = {
-   url = "git://github.com/torch/sdl2-ffi.git"
+   url = "git+https://github.com/arkenidar/lua-sdl2-ffi-luajit.git"
 }
 
 description = {

--- a/test/video/test-bmp.lua
+++ b/test/video/test-bmp.lua
@@ -15,10 +15,12 @@ local windowsurface = sdl.getWindowSurface(window)
 
 local image = sdl.loadBMP("lena.bmp")
 
-sdl.upperBlit(image, nil, windowsurface, nil)
+-- moved inside the loop
+--- sdl.upperBlit(image, nil, windowsurface, nil)
+--- sdl.updateWindowSurface(window)
 
-sdl.updateWindowSurface(window)
-sdl.freeSurface(image)
+-- moved at the end
+--- sdl.freeSurface(image)
 
 local running = true
 local event = ffi.new('SDL_Event')
@@ -28,7 +30,15 @@ while running do
          running = false
       end
    end
+
+   -- added
+   sdl.upperBlit(image, nil, windowsurface, nil)
+   sdl.updateWindowSurface(window)
+
 end
+
+-- added
+sdl.freeSurface(image)
 
 sdl.destroyWindow(window)
 sdl.quit()

--- a/windows-cygwin-setup.txt
+++ b/windows-cygwin-setup.txt
@@ -1,0 +1,41 @@
+# install cygwin and ...
+# - curl
+# - wget
+# - gcc-core
+# - git
+# - make
+# - unzip
+# ... in it (via setup.exe)
+
+# install luajit (required below)
+git clone https://luajit.org/git/luajit.git
+cd ~/luajit && make && make install
+ln -sf luajit-2.1.0-beta3 /usr/local/bin/luajit # version?
+which luajit
+cp ~/luajit/src/cyglua51.dll /usr/bin
+luajit -v
+
+cd ~ && ls
+
+# install luarocks (required below)
+cd ~/luarocks-3.9.1 && ls
+./configure && make && make install
+which luarocks
+luarocks-admin
+mkdir ~/.luarocks
+luarocks config variables.LUALIB "libluajit-5.1.dll.a" # for luarocks config variables.LUA_LIBDIR
+luarocks config variables.LUA_LIBDIR ~/luajit/src
+luarocks-admin
+
+cd ~ && ls
+
+# requires: luarocks
+# install luajit-ffi-sdl : "arkenidar/lua-sdl2-ffi-luajit"
+luarocks install https://raw.githubusercontent.com/arkenidar/lua-sdl2-ffi-luajit/master/rocks/sdl2-scm-1.rockspec
+# install SDL redistributable
+cp ~/SDL2.dll /usr/bin/cygSDL2.dll # from website libsdl.org
+
+# requires: luajit
+# test video feature by showing an image
+git clone https://github.com/arkenidar/lua-sdl2-ffi-luajit
+cd ~/lua-sdl2-ffi-luajit/test/video/ && luajit test-bmp.lua # works!


### PR DESCRIPTION
-- url = "git://github.com/torch/sdl2-ffi.git" -- initial but did not work for me
uses "git://"

BUT this works for me:
url = "git+https://github.com/torch/sdl2-ffi.git"
by using "git+https://{...}"

a superfluous forking could be avoided perhaps

this link was enlightening for fixing : https://github.com/luarocks/luarocks/wiki/Rockspec-format